### PR TITLE
Fix : Sadang-bound Train Display

### DIFF
--- a/src/app/components/subway/Subway.tsx
+++ b/src/app/components/subway/Subway.tsx
@@ -319,7 +319,14 @@ const Subway = ({ station }: SubwayStop) => {
     const filtered =
       timetable.data
         ?.filter(
-          (val) => val.direction === direction && val.destination !== null,
+          (val) =>
+            val.direction === direction &&
+            val.destination !== null &&
+            !(
+              val.line === '4' &&
+              val.direction === 2 &&
+              val.destination === '사당'
+            ),
         )
         .sort(compare)
         .slice(0, 2) ?? []

--- a/src/app/components/subway/Subway.tsx
+++ b/src/app/components/subway/Subway.tsx
@@ -272,6 +272,8 @@ const openRailblue = (btrainNo: string): void => {
   )
 }
 
+const VALID_SOUTHBOUND_DESTINATIONS = ['안산', '오이도', '인천']
+
 const Subway = ({ station }: SubwayStop) => {
   const timetable = useQuery({
     queryKey: ['subway_timetable', station],
@@ -322,11 +324,8 @@ const Subway = ({ station }: SubwayStop) => {
           (val) =>
             val.direction === direction &&
             val.destination !== null &&
-            !(
-              val.line === '4' &&
-              val.direction === 2 &&
-              val.destination === '사당'
-            ),
+            (direction !== 2 ||
+              VALID_SOUTHBOUND_DESTINATIONS.includes(val.destination)),
         )
         .sort(compare)
         .slice(0, 2) ?? []


### PR DESCRIPTION
## Describe your Pull Request

- Hide southbound Line 4 trains terminating at Sadang from the subway arrival list.
- These trains terminate before reaching HYU and Jungang Station, but could appear around midnight.

## Additional content

- Verified with Prettier, ESLint, production build, and browser before/after screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subway timetable filtering to exclude Line 4 trains bound for 사당 when traveling in direction 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->